### PR TITLE
Revert mm files

### DIFF
--- a/mm-cli/Makefile
+++ b/mm-cli/Makefile
@@ -18,7 +18,7 @@ include $(TOPDIR)/rules.mk
 TITLE:=mm-cli
 PKG_NAME:=mm-cli
 PKG_VERSION:=0.0.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PYPI_NAME:=$(PKG_NAME)
 PYPI_SOURCE_NAME:=mm-cli

--- a/mm-cli/Makefile
+++ b/mm-cli/Makefile
@@ -49,10 +49,7 @@ define Package/python3-mm-cli/description
   A CLI application for connecting to the mesh.
 endef
 
-define Package/python3-mm-cli/install
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) ./files/mm $(1)/usr/bin
-endef
-
 $(eval $(call Py3Package,python3-mm-cli))
 $(eval $(call BuildPackage,python3-mm-cli))
+$(eval $(call BuildPackage,python3-mm-cli-src))
+

--- a/mm-cli/files/mm
+++ b/mm-cli/files/mm
@@ -1,2 +1,0 @@
-#!/bin/sh
-/usr/bin/python3 -m mm_cli $@


### PR DESCRIPTION
not the Install directive overwrites what should be copied to rootfs -- no good. 
we need another way to use mm, we either include it in the source and add something like  
 /etc/profile `alias mm='/usr/bin/python3 -m mm_cli'`

```
root@OpenWrt:/tmp# opkg install python3-mm-cli_0.0.3-2_aarch64_cortex-a53.ipk 
Upgrading python3-mm-cli on root from 0.0.3-1 to 0.0.3-2...
Removing obsolete file /usr/lib/python3.8/site-packages/mm_cli/gateway.pyc.
Removing obsolete file /usr/lib/python3.8/site-packages/mm_cli/util.pyc.
Removing obsolete file /usr/lib/python3.8/site-packages/mm_cli-0.0.3-py3.8.egg-info/SOURCES.txt.
Removing obsolete file /usr/lib/python3.8/site-packages/mm_cli/client.pyc.
Removing obsolete file /usr/lib/python3.8/site-packages/mm_cli/__main__.pyc.
Removing obsolete file /usr/lib/python3.8/site-packages/mm_cli-0.0.3-py3.8.egg-info/PKG-INFO.
Removing obsolete file /usr/lib/python3.8/site-packages/mm_cli/hemicarp-future.pyc.
Removing obsolete file /usr/lib/python3.8/site-packages/mm_cli-0.0.3-py3.8.egg-info/top_level.txt.
Removing obsolete file /usr/lib/python3.8/site-packages/mm_cli/__init__.pyc.
Removing obsolete file /usr/lib/python3.8/site-packages/mm_cli-0.0.3-py3.8.egg-info/requires.txt.
Removing obsolete file /usr/lib/python3.8/site-packages/mm_cli-0.0.3-py3.8.egg-info/dependency_links.txt.

```